### PR TITLE
Handle HTTP errors in transformResponse

### DIFF
--- a/lib/angular-dsv.js
+++ b/lib/angular-dsv.js
@@ -22,7 +22,7 @@ function dsvFactory ($http, $window) {
       var config = {
         method: 'get',
         transformResponse: function (data) {
-          return _dsv.parse(data, f);
+          return data == null ? [] : _dsv.parse(data, f);
         }
       };
       angular.extend(config, requestConfig);
@@ -53,7 +53,7 @@ function dsvFactory ($http, $window) {
         method: 'get',
         url: url,
         transformResponse: function (data) {
-          return _dsv.parseRows(data, params.f);
+          return data == null ? [] : _dsv.parseRows(data, params.f);
         }
       };
 


### PR DESCRIPTION
If a request is canceled, I get errors like this:

```
TypeError: Cannot read property 'length' of null
    at Dsv.parseRows (built.js?3.6.4-default:49767)
    at Dsv.parse (built.js?3.6.4-default:49754)
    at transformResponse (built.js?3.6.4-default:49680)
    at transformData (built.js?3.6.4-default:10873)
    at transformResponse (built.js?3.6.4-default:11737)
    at processQueue (built.js?3.6.4-default:16624)
```
